### PR TITLE
fix rotten tomato within set collections

### DIFF
--- a/resources/lib/LibraryMonitor.py
+++ b/resources/lib/LibraryMonitor.py
@@ -905,10 +905,9 @@ class LibraryMonitor(threading.Thread):
         WINDOW.clearProperty('SkinHelper.RottenTomatoesConsensus')
         WINDOW.clearProperty('SkinHelper.RottenTomatoesAwards')
         WINDOW.clearProperty('SkinHelper.RottenTomatoesBoxOffice')
-
         contenttype = getCurrentContentType()
         imdbnumber = xbmc.getInfoLabel("ListItem.IMDBNumber")
-        if contenttype == "movies" and imdbnumber:
+        if (contenttype == "movies" or contenttype=="setmovies") and imdbnumber:
             if self.rottenCache.has_key(imdbnumber):
                 #get data from cache
                 result = self.rottenCache[imdbnumber]
@@ -918,7 +917,6 @@ class LibraryMonitor(threading.Thread):
                 result = json.loads(res.content)
                 if result:
                     self.rottenCache[imdbnumber] = result
-
             if result:
                 criticsscore = result['tomatoMeter']
                 criticconsensus = result['tomatoConsensus']


### PR DESCRIPTION
For some reason when the movie is in a set the content type when called is "setmovies" rather than just a movie. I expected the setmovies type to only be the content type on the actual set/parent item. This change makes sure that the ratings etc are populated in that instance
