### PR TITLE
Jump to letter: Enable "#" to jump to the beginning of a list

### DIFF
--- a/resources/lib/plugin_content.py
+++ b/resources/lib/plugin_content.py
@@ -310,7 +310,7 @@ class PluginContent:
             for i in range(int(xbmc.getInfoLabel("Container.NumItems"))):
                 all_letters.append(xbmc.getInfoLabel("Listitem(%s).SortLetter" % i).upper())
             start_number = ""
-            for number in ["2", "3", "4", "5", "6", "7", "8", "9"]:
+            for number in ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]:
                 if number in all_letters:
                     start_number = number
                     break
@@ -335,27 +335,29 @@ class PluginContent:
             xbmcplugin.setResolvedUrl(handle=int(sys.argv[1]), succeeded=False, listitem=xbmcgui.ListItem())
         letter = self.params.get("letter", "").upper()
         jumpcmd = ""
-        if letter in ["A", "B", "C", "2"]:
-            jumpcmd = "2"
-        elif letter in ["D", "E", "F", "3"]:
-            jumpcmd = "3"
-        elif letter in ["G", "H", "I", "4"]:
-            jumpcmd = "4"
-        elif letter in ["J", "K", "L", "5"]:
-            jumpcmd = "5"
-        elif letter in ["M", "N", "O", "6"]:
-            jumpcmd = "6"
-        elif letter in ["P", "Q", "R", "S", "7"]:
-            jumpcmd = "7"
-        elif letter in ["T", "U", "V", "8"]:
-            jumpcmd = "8"
-        elif letter in ["W", "X", "Y", "Z", "9"]:
-            jumpcmd = "9"
+        if letter in ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]:
+            jumpcmd = "firstpage"
+        elif letter in ["A", "B", "C"]:
+            jumpcmd = "jumpsms2"
+        elif letter in ["D", "E", "F"]:
+            jumpcmd = "jumpsms3"
+        elif letter in ["G", "H", "I"]:
+            jumpcmd = "jumpsms4"
+        elif letter in ["J", "K", "L"]:
+            jumpcmd = "jumpsms5"
+        elif letter in ["M", "N", "O"]:
+            jumpcmd = "jumpsms6"
+        elif letter in ["P", "Q", "R", "S"]:
+            jumpcmd = "jumpsms7"
+        elif letter in ["T", "U", "V"]:
+            jumpcmd = "jumpsms8"
+        elif letter in ["W", "X", "Y", "Z"]:
+            jumpcmd = "jumpsms9"
         if jumpcmd:
             xbmc.executebuiltin("SetFocus(50)")
             for i in range(40):
                 xbmc.executeJSONRPC('{ "jsonrpc": "2.0", "method": "Input.ExecuteAction",\
-                    "params": { "action": "jumpsms%s" }, "id": 1 }' % (jumpcmd))
+                    "params": { "action": "%s" }, "id": 1 }' % (jumpcmd))
                 xbmc.sleep(50)
                 if xbmc.getInfoLabel("ListItem.Sortletter").upper() == letter:
                     break


### PR DESCRIPTION
Currently the "#" does nothing. 
But since 0-9 are always at the beginning it can be mapped with "action(firstpage)"