### PR TITLE
Don't refresh player properties after un-pausing playback

### DIFF
--- a/resources/lib/kodi_monitor.py
+++ b/resources/lib/kodi_monitor.py
@@ -58,7 +58,7 @@ class KodiMonitor(xbmc.Monitor):
                 self.win.clearProperty("TrailerPlaying")
                 self.reset_win_props()
 
-            if method == "Player.OnPlay":
+            if method == "Player.OnPlay" and not getCondVisibility("Player.DisplayAfterSeek"):
                 if not self.monitoring_stream:
                     self.reset_win_props()
                 if self.wait_for_player():


### PR DESCRIPTION
This fixes skin issues with animations and visibility conditions when pausing and resuming.