### PR TITLE
Use threading.Thread(target=) instead of _thread.start_new_thread() 

### DIFF
--- a/resources/lib/listitem_monitor.py
+++ b/resources/lib/listitem_monitor.py
@@ -66,7 +66,7 @@ class ListItemMonitor(threading.Thread):
 
             # do some background stuff every 30 minutes
             if (self.delayed_task_interval >= 1800) and not self.exit:
-                threading.thread(target=self.do_background_work).start()
+                threading.Thread(target=self.do_background_work).start()
                 self.delayed_task_interval = 0
 
             # skip if any of the artwork context menus is opened
@@ -173,7 +173,7 @@ class ListItemMonitor(threading.Thread):
             self.win.setProperty("curlistitem", cur_listitem)
             if cur_listitem and cur_listitem != "..":
                 # set listitem details in background thread
-                threading.thread(
+                threading.Thread(
                     target=self.set_listitem_details, 
                     args=(cur_listitem, content_type, cont_prefix)
                 ).start()
@@ -280,7 +280,7 @@ class ListItemMonitor(threading.Thread):
                 self.lookup_busy[cur_listitem] = True
 
                 # clear all window props, do this delayed to prevent flickering of the screen
-                threading.thread(
+                threading.Thread(
                     target=self.delayed_flush, 
                     args=(cur_listitem,)
                 ).start()

--- a/resources/lib/searchdialog.py
+++ b/resources/lib/searchdialog.py
@@ -278,7 +278,7 @@ class SearchBackgroundThread(threading.Thread):
         threading.Thread.__init__(self, *args)
         self.mutils = MetadataUtils()
         self.actors = []
-        threading.Thread(target=self.set_actors)
+        threading.Thread(target=self.set_actors).start()
 
     def set_search(self, searchstr):
         '''set search query'''

--- a/resources/lib/searchdialog.py
+++ b/resources/lib/searchdialog.py
@@ -9,10 +9,6 @@
 
 import os, sys
 import threading
-if sys.version_info.major == 3:
-    import _thread as thread
-else:
-    import thread
 from resources.lib.utils import getCondVisibility, try_decode
 import xbmc
 import xbmcgui
@@ -282,7 +278,7 @@ class SearchBackgroundThread(threading.Thread):
         threading.Thread.__init__(self, *args)
         self.mutils = MetadataUtils()
         self.actors = []
-        thread.start_new_thread(self.set_actors, ())
+        threading.Thread(target=self.set_actors)
 
     def set_search(self, searchstr):
         '''set search query'''


### PR DESCRIPTION
The use of the low level API causes XBMCHelper issues and constant new Kodi windows on OSX with Kodi 19.2 onwards.

The use of the standard API rather than the low level API should work on Py2 and Py3 and be more compatible in general avoiding edge case issues.