### PR TITLE
Add support for skins to use a basic counter value

### DIFF
--- a/resources/lib/main_module.py
+++ b/resources/lib/main_module.py
@@ -673,6 +673,28 @@ class MainModule:
             percentage = percentage + (roundsteps - percentage) % roundsteps
         xbmc.executebuiltin("Skin.SetString(%s,%s)" % (skinstring, percentage))
 
+    def increasecount(self):
+        '''helper to increase a counter value and write result to a window prop or skinstring'''
+        value = int(self.params.get("value"))
+        skinstring = self.params.get("skinstring")
+        windowprop = self.params.get("winprop")
+        value += 1
+        if windowprop:
+            self.win.setProperty(windowprop, str(value))
+        if skinstring:
+            xbmc.executebuiltin("Skin.SetString(%s,%s)" % (skinstring, value))
+
+    def decreasecount(self):
+        '''helper to decrease a counter value and write result to a window prop or skinstring'''
+        value = int(self.params.get("value"))
+        skinstring = self.params.get("skinstring")
+        windowprop = self.params.get("winprop")
+        value -= 1
+        if windowprop:
+            self.win.setProperty(windowprop, str(value))
+        if skinstring:
+            xbmc.executebuiltin("Skin.SetString(%s,%s)" % (skinstring, value))
+
     def setresourceaddon(self):
         '''helper to let the user choose a resource addon and set that as skin string'''
         from .resourceaddons import setresourceaddon


### PR DESCRIPTION
This PR adds two new script actions for skins to use a basic counter value, `increasecount` and `decreasecount`. It is especially suited to tracking/manipulating pagination with custom static list items such as next page and previous page.

The input value can be a standard integer or even an infolabel/custom window property, and the ouput value can be directed to a window property or a skin string, similar to other script actions in the helper service.

As an example pagination use case, please refer to [this issue](https://github.com/jurialmunkey/plugin.video.themoviedb.helper/issues/676#issuecomment-1166178416) and its associated comments.

Since the Kodi skinning engine doesn't currently support math functions/counters directly, this tool will be invaluable to skinners and hopefully in future more math operations can be added as needed to the helper service.
