### PR TITLE
Update plugin_content.py

### DIFF
--- a/resources/lib/plugin_content.py
+++ b/resources/lib/plugin_content.py
@@ -326,6 +326,7 @@ class PluginContent:
                 if letter not in all_letters:
                     lipath = "noop"
                     listitem.setProperty("NotAvailable", "true")
+                    continue
                 else:
                     lipath = "plugin://script.skin.helper.service/?action=alphabetletter&letter=%s" % letter
                 xbmcplugin.addDirectoryItem(int(sys.argv[1]), lipath, listitem, isFolder=False)


### PR DESCRIPTION
Made a very small suggestion on "alphabetletter".
This way, it will only list the initial letters of the items that are in the list. For example, there is no item that starts with the letter "P", so the letter "P" will not appear in the list.