### PR TITLE
Update listitem_monitor.py - check_screensaver()

### DIFF
--- a/resources/lib/listitem_monitor.py
+++ b/resources/lib/listitem_monitor.py
@@ -26,8 +26,8 @@ class ListItemMonitor(threading.Thread):
     last_folder = ""
     last_listitem = ""
     foldercontent = {}
-    screensaver_setting = None
-    screensaver_disabled = False
+    # screensaver_setting = None
+    # screensaver_disabled = False
     lookup_busy = {}
     enable_extendedart = False
     enable_musicart = False
@@ -224,26 +224,13 @@ class ListItemMonitor(threading.Thread):
 
     def check_screensaver(self):
         '''Allow user to disable screensaver on fullscreen music playback'''
-        if getCondVisibility(
-                "Window.IsActive(visualisation) + Skin.HasSetting(SkinHelper.DisableScreenSaverOnFullScreenMusic)"):
-            if not self.screensaver_disabled:
-                # disable screensaver when fullscreen music active
-                self.screensaver_disabled = True
-                screensaver_setting = kodi_json('Settings.GetSettingValue', '{"setting":"screensaver.mode"}')
-                if screensaver_setting:
-                    self.screensaver_setting = screensaver_setting
-                    kodi_json('Settings.SetSettingValue', {"setting": "screensaver.mode", "value": None})
-                    log_msg(
-                        "Disabled screensaver while fullscreen music playback - previous setting: %s" %
-                        self.screensaver_setting, xbmc.LOGINFO)
-        elif self.screensaver_disabled and self.screensaver_setting:
-            # enable screensaver again after fullscreen music playback was ended
-            kodi_json('Settings.SetSettingValue', {"setting": "screensaver.mode", "value": self.screensaver_setting})
-            self.screensaver_disabled = False
-            self.screensaver_setting = None
-            log_msg(
-                "fullscreen music playback ended - restoring screensaver: %s" %
-                self.screensaver_setting, xbmc.LOGINFO)
+        # Prevent any screensaver to start.
+        # Built-in system function 'InhibitScreensaver()' was added in Kodi 19 Matrix.
+        if getCondVisibility("Window.IsActive(visualisation) + Skin.HasSetting(SkinHelper.DisableScreenSaverOnFullScreenMusic)"):
+            xbmc.executebuiltin('InhibitScreensaver(true)')
+        # Restore the screensaver default behaviour.            
+        elif getCondVisibility("!Window.IsActive(visualisation) | !Skin.HasSetting(SkinHelper.DisableScreenSaverOnFullScreenMusic)"):
+            xbmc.executebuiltin('InhibitScreensaver(false)')
 
     @staticmethod
     def check_osd():


### PR DESCRIPTION
As already mentioned by @Fuchs246 in the Kodi-forum [https://forum.kodi.tv/showthread.php?tid=235676&pid=3170628#pid3170628](https://forum.kodi.tv/showthread.php?tid=235676&pid=3170628#pid3170628), the function to disable the screensaver on fullscreen music playback isn't working at the moment. Using the new built-in function 'InhibitScreensaver' should do the job. 